### PR TITLE
ADDING UPDATE METHOD FOR EVENTS

### DIFF
--- a/ApiCalendar.js
+++ b/ApiCalendar.js
@@ -162,6 +162,23 @@ class ApiCalendar {
             'resource': event,
         });
     }
+    
+     /*
+     * Update Calendar event
+     * @param {string} calendarId for the event.
+     * @param {string} eventId of the event.
+     * @param {object} event with start and end dateTime
+     * @returns {any}
+     */
+    updateEvent(eventPatch, eventId, calendarId = this.calendar) {
+        return this.gapi.client.calendar.events.patch({
+            'calendarId': calendarId,
+            'eventId': eventId,
+            'resource': eventPatch,
+        });
+    }
+    
+    
     /**
      * Create Calendar event
      * @param {string} calendarId for the event.


### PR DESCRIPTION
THEME: Enhancing ApiCalendar.js to support updateEvent functionality

TITLE: A function updateEvent() is added just like createEvent which takes the calendarId, eventId and event data as parameters and executes the patch method of event.

TYPE: Feature/Enhancement


ISSUE_NUMBER: 35
TITLE: Patch-and-Update methods-are-not-included-for-an-existing-event

COMMIT DETAILS:

The update method for an event is added
method name : updateEvent
params : eventId, calendarId, eventPatch (the updated event data)
Issue Ref : https://github.com/Kubessandra/react-google-calendar-api/issues/35