### PR TITLE
add param sendUpdate on createEvent / updateEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You need to be registered with handleAuthClick.
     * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
     * @returns {any} Promise on the event.
     */
-   public createEvent(event: object, calendarId: string = this.calendar, sendUpdates = string,): any {
+   public createEvent(event: object, calendarId: string = this.calendar, sendUpdates: string = 'none',): any {
 ```
 
 ### Create Event From Now:
@@ -214,9 +214,10 @@ if (ApiCalendar.sign)
     * @param {string} calendarId for the event.
     * @param {string} eventId of the event.
     * @param {object} event with details to update, e.g. summary
+    * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
     * @returns {any} Promise object with result
     */
-   public updateEvent(event: object, eventId: string, calendarId: string = this.calendar): any
+   public updateEvent(event: object, eventId: string, calendarId: string = this.calendar, sendUpdates: string = 'none'): any
 ```
 
 #### Example

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You need to be registered with handleAuthClick.
     * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
     * @returns {any} Promise on the event.
     */
-   public createEvent(event: object, sendUpdates = string, calendarId: string = this.calendar): any {
+   public createEvent(event: object, calendarId: string = this.calendar, sendUpdates = string,): any {
 ```
 
 ### Create Event From Now:

--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ You need to be registered with handleAuthClick.
     * Create calendar event
     * @param {string} CalendarId for the event by default use 'primary'.
     * @param {object} Event with start and end dateTime
+    * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
     * @returns {any} Promise on the event.
     */
-   public createEvent(event: object, calendarId: string = this.calendar): any {
+   public createEvent(event: object, sendUpdates = boolean, calendarId: string = this.calendar): any {
 ```
 
 ### Create Event From Now:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You need to be registered with handleAuthClick.
     * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
     * @returns {any} Promise on the event.
     */
-   public createEvent(event: object, sendUpdates = boolean, calendarId: string = this.calendar): any {
+   public createEvent(event: object, sendUpdates = string, calendarId: string = this.calendar): any {
 ```
 
 ### Create Event From Now:

--- a/src/ApiCalendar.js
+++ b/src/ApiCalendar.js
@@ -188,15 +188,13 @@ class ApiCalendar {
      * Create Calendar event
      * @param {string} calendarId for the event.
      * @param {object} event with start and end dateTime
-     * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
      * @returns {any}
      */
-    createEvent(event, sendUpdates = false, calendarId = this.calendar) {
+    createEvent(event, calendarId = this.calendar) {
         if (this.gapi) {
             return this.gapi.client.calendar.events.insert({
                 calendarId: calendarId,
                 resource: event,
-                sendUpdates: sendUpdates,
             });
         }
         else {
@@ -241,17 +239,15 @@ class ApiCalendar {
      * Update Calendar event
      * @param {string} calendarId for the event.
      * @param {string} eventId of the event.
-     * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
      * @param {object} event with details to update, e.g. summary
      * @returns {any}
      */
-    updateEvent(event, eventId, sendUpdates = false, calendarId = this.calendar) {
+    updateEvent(event, eventId, calendarId = this.calendar) {
         if (this.gapi) {
             return this.gapi.client.calendar.events.patch({
                 calendarId: calendarId,
                 eventId: eventId,
                 resource: event,
-                sendUpdates: sendUpdates,
             });
         }
         else {

--- a/src/ApiCalendar.js
+++ b/src/ApiCalendar.js
@@ -188,13 +188,15 @@ class ApiCalendar {
      * Create Calendar event
      * @param {string} calendarId for the event.
      * @param {object} event with start and end dateTime
+     * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
      * @returns {any}
      */
-    createEvent(event, calendarId = this.calendar) {
+    createEvent(event, sendUpdates = false, calendarId = this.calendar) {
         if (this.gapi) {
             return this.gapi.client.calendar.events.insert({
                 calendarId: calendarId,
                 resource: event,
+                sendUpdates: sendUpdates,
             });
         }
         else {
@@ -239,15 +241,17 @@ class ApiCalendar {
      * Update Calendar event
      * @param {string} calendarId for the event.
      * @param {string} eventId of the event.
+     * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
      * @param {object} event with details to update, e.g. summary
      * @returns {any}
      */
-    updateEvent(event, eventId, calendarId = this.calendar) {
+    updateEvent(event, eventId, sendUpdates = false, calendarId = this.calendar) {
         if (this.gapi) {
             return this.gapi.client.calendar.events.patch({
                 calendarId: calendarId,
                 eventId: eventId,
                 resource: event,
+                sendUpdates: sendUpdates,
             });
         }
         else {

--- a/src/ApiCalendar.ts
+++ b/src/ApiCalendar.ts
@@ -208,13 +208,15 @@ class ApiCalendar {
    * Create Calendar event
    * @param {string} calendarId for the event.
    * @param {object} event with start and end dateTime
+   * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
    * @returns {any}
    */
-  public createEvent(event: object, calendarId: string = this.calendar): any {
+  public createEvent(event: object, calendarId: string = this.calendar, sendUpdates?: string ): any {
     if (this.gapi) {
       return this.gapi.client.calendar.events.insert({
         calendarId: calendarId,
         resource: event,
+        sendUpdates: sendUpdates,
       });
     } else {
       console.log('Error: this.gapi not loaded');
@@ -260,18 +262,21 @@ class ApiCalendar {
    * @param {string} calendarId for the event.
    * @param {string} eventId of the event.
    * @param {object} event with details to update, e.g. summary
+   * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
    * @returns {any}
    */
   updateEvent(
     event: object,
     eventId: string,
-    calendarId: string = this.calendar
+    calendarId: string = this.calendar,
+    sendUpdates?: string,
   ): any {
     if (this.gapi) {
       return this.gapi.client.calendar.events.patch({
         calendarId: calendarId,
         eventId: eventId,
         resource: event,
+        sendUpdates: sendUpdates,
       });
     } else {
       console.log('Error: gapi is not loaded use onLoad before please.');

--- a/src/ApiCalendar.ts
+++ b/src/ApiCalendar.ts
@@ -211,7 +211,7 @@ class ApiCalendar {
    * @param {string} sendUpdates Acceptable values are: "all", "externalOnly", "none"
    * @returns {any}
    */
-  public createEvent(event: object, calendarId: string = this.calendar, sendUpdates?: string ): any {
+  public createEvent(event: object, calendarId: string = this.calendar, sendUpdates: string = 'none' ): any {
     if (this.gapi) {
       return this.gapi.client.calendar.events.insert({
         calendarId: calendarId,
@@ -269,7 +269,7 @@ class ApiCalendar {
     event: object,
     eventId: string,
     calendarId: string = this.calendar,
-    sendUpdates?: string,
+    sendUpdates: string = 'none',
   ): any {
     if (this.gapi) {
       return this.gapi.client.calendar.events.patch({


### PR DESCRIPTION
sendUpdate default is false

Guests who should receive notifications about the event update (for example, title changes, etc.).
Acceptable values are:
"all": Notifications are sent to all guests.
"externalOnly": Notifications are sent to non-Google Calendar guests only.
"none": No notifications are sent. This value should only be used for migration use cases (note that in most migration cases the import method should be used).

Fixes #45 